### PR TITLE
Updated IP2 nodes

### DIFF
--- a/assets/data/nodes.json
+++ b/assets/data/nodes.json
@@ -66,7 +66,7 @@
     },
     {
       "id": "ip2-int01.ipnt.uk",
-      "publicKey": "",
+      "publicKey": "780d0939f90b22d3bd7cbedcaf4e8d468a12c01886ab24b8cfa11eab2f5516c5",
       "name": "IP2 Integration 1",
       "memberId": "louis",
       "area": "IP2",
@@ -86,24 +86,24 @@
       "channels": []
     },
     {
-      "id": "ip2-tst01.ipnt.uk",
-      "publicKey": "E1E0AE4348289EE3498399CCB0A95B78FAB89A1426F05D6072B80D1FD1201CD1",
-      "name": "IP2 Test Repeater 1",
+      "id": "ip2-int02.ipnt.uk",
+      "publicKey": "30121dc60362c633c457ffa18f49b3e1d6823402c33709f32d7df70612250b96",
+      "name": "IP2 Integration 2",
       "memberId": "louis",
       "area": "IP2",
       "location": {
-        "lat": 52.0352745,
-        "lng": 1.129809,
+        "lat": 52.0354539,
+        "lng": 1.1295338,
         "description": "Fountains Road"
       },
       "hardware": "Heltec V3",
-      "antenna": "McGill 6dBi Omni",
+      "antenna": "Generic 5dBi Whip",
       "elevation": 25,
       "showOnMap": false,
       "isPublic": true,
       "isOnline": true,
-      "isTesting": true,
-      "meshRole": "repeater",
+      "isTesting": false,
+      "meshRole": "integration",
       "channels": []
     },
     {


### PR DESCRIPTION
This pull request updates the node definitions in the `assets/data/nodes.json` file, focusing on changes to the IP2 area nodes. The main changes include updating public keys, renaming and reconfiguring a node, and adjusting location and hardware details.

**IP2 node updates:**

* Updated the `publicKey` for `ip2-int01.ipnt.uk` to a new value.
* Replaced the `ip2-tst01.ipnt.uk` node ("IP2 Test Repeater 1") with a new node `ip2-int02.ipnt.uk` ("IP2 Integration 2"), including changes to the public key, name, location coordinates, antenna type, testing status, and mesh role.