### PR TITLE
Updated Craig's profile

### DIFF
--- a/assets/data/members.json
+++ b/assets/data/members.json
@@ -74,8 +74,8 @@
       "bio": "",
       "contactPreference": "discord",
       "isPublic": true,
-      "nodeName": "",
-      "nodePublicKey": "",
+      "nodeName": "Craig M7XCN",
+      "nodePublicKey": "c7d9e795bf67ce74b65a176abb25e8c835074b776c850afefdf0d690879d70e1",
       "socialLinks": {
         "github": "",
         "twitter": ""


### PR DESCRIPTION
This pull request updates the public node information for a member in the `assets/data/members.json` file. The member now has a specified node name and public key.

Member profile updates:

* Set the `nodeName` to "Craig M7XCN" for the member.
* Set the `nodePublicKey` to "c7d9e795bf67ce74b65a176abb25e8c835074b776c850afefdf0d690879d70e1" for the member.